### PR TITLE
Cleared the `ACC_VARARGS` access flag on all shadow methods

### DIFF
--- a/galette-agent/src/main/java/edu/neu/ccs/prl/galette/internal/transform/ShadowMethodCreator.java
+++ b/galette-agent/src/main/java/edu/neu/ccs/prl/galette/internal/transform/ShadowMethodCreator.java
@@ -60,7 +60,10 @@ public final class ShadowMethodCreator {
     }
 
     private MethodNode createShadow(MethodNode mn) {
-        int shadowAccess = (mn.access & ~Opcodes.ACC_NATIVE) | Opcodes.ACC_SYNTHETIC;
+        // Start with the original method's access flags
+        // then, clear the ACC_NATIVE and ACC_VARARGS flags
+        // and set ACC_SYNTHETIC flag
+        int shadowAccess = (mn.access & ~Opcodes.ACC_NATIVE & ~Opcodes.ACC_VARARGS) | Opcodes.ACC_SYNTHETIC;
         MethodNode shadow = new MethodNode(
                 GaletteTransformer.ASM_VERSION,
                 shadowAccess,


### PR DESCRIPTION
Cleared the `ACC_VARARGS` access flag on all shadow methods.

As noted in the [JVM 21 spec](https://docs.oracle.com/javase/specs/jvms/se21/html/jvms-4.html#jvms-4.6): "[a] future edition of this specification may require that the last parameter descriptor of the method descriptor is an array type if the ACC_VARARGS flag is set in the access_flags item." This constraint appears to now be enforced by certain JDKs. Since Galette-added shadow methods have a trailing argument of type `TagFrame`, retaining the `ACC_VARARGS` access flag from the original method produces errors like the one described in [Issue 2](https://github.com/neu-se/galette/issues/2#issuecomment-3292028485). Clearing the `ACC_VARARGS` access flag should resolve this issue.